### PR TITLE
OSOE-624: Moving DebugHelper and TestOutputHelperExtensions to Lombiq.Tests

### DIFF
--- a/Extensions/TestOutputHelperExtensions.cs
+++ b/Extensions/TestOutputHelperExtensions.cs
@@ -1,0 +1,20 @@
+using Lombiq.Tests.Helpers;
+
+namespace Xunit.Abstractions;
+
+public static class TestOutputHelperExtensions
+{
+    public static void WriteLineTimestampedAndDebug(this ITestOutputHelper testOutputHelper, string format, params object[] args)
+    {
+        testOutputHelper.WriteLineTimestamped(format, args);
+        DebugHelper.WriteLineTimestamped(format, args);
+    }
+
+    public static void WriteLineTimestamped(this ITestOutputHelper testOutputHelper, string format, params object[] args)
+    {
+        // Preventing "FormatException : Input string was not in a correct format." exceptions if the message contains
+        // characters used in string formatting but it shouldn't actually be formatted.
+        if (args == null || args.Length == 0) testOutputHelper.WriteLine(DebugHelper.PrefixWithTimestamp(format));
+        else testOutputHelper.WriteLine(DebugHelper.PrefixWithTimestamp(format), args);
+    }
+}

--- a/Helpers/DebugHelper.cs
+++ b/Helpers/DebugHelper.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Lombiq.Tests.Helpers;
+
+public static class DebugHelper
+{
+    public static void WriteLineTimestamped(string format, params object[] args)
+    {
+        // Preventing "FormatException : Input string was not in a correct format." exceptions if the message contains
+        // characters used in string formatting but it shouldn't actually be formatted.
+        if (args == null || args.Length == 0) Debug.WriteLine(PrefixWithTimestamp(format));
+        else Debug.WriteLine(PrefixWithTimestamp(format), args);
+    }
+
+    // Note that this uses UTC, while Atata's log uses the local time zone:
+    // https://github.com/atata-framework/atata/issues/483.
+    public static string PrefixWithTimestamp(string message) =>
+        $"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.ffff", CultureInfo.InvariantCulture)} - {message}";
+}


### PR DESCRIPTION
[OSOE-624](https://lombiq.atlassian.net/browse/OSOE-624)

[OSOE-624]: https://lombiq.atlassian.net/browse/OSOE-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ