### PR TITLE
OSOE-852: Change NuGet metadata to use license expression

### DIFF
--- a/Lombiq.Tests.csproj
+++ b/Lombiq.Tests.csproj
@@ -15,11 +15,10 @@
     <PackageIcon>NuGetIcon.png</PackageIcon>
     <RepositoryUrl>https://github.com/Lombiq/Testing-Toolbox</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Lombiq/Testing-Toolbox</PackageProjectUrl>
-    <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="License.md" Pack="true" PackagePath="" />
     <None Include="Readme.md" />
     <None Include="NuGetIcon.png" Pack="true" PackagePath="" />
   </ItemGroup>


### PR DESCRIPTION
[OSOE-852](https://lombiq.atlassian.net/browse/OSOE-852)

[OSOE-852]: https://lombiq.atlassian.net/browse/OSOE-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ