### PR TITLE
OSOE-976: Removing unused FluentAssertions dependency, updating Microsoft.AspNetCore.Mvc.Testing to 8.0.12

### DIFF
--- a/Lombiq.Tests.csproj
+++ b/Lombiq.Tests.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/Lombiq.Tests.csproj
+++ b/Lombiq.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />


### PR DESCRIPTION
[OSOE-976](https://lombiq.atlassian.net/browse/OSOE-976)

[OSOE-976]: https://lombiq.atlassian.net/browse/OSOE-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ